### PR TITLE
Stress units

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ More than 2 ML_AB files can be combined at once, e.g.
 mlff merge ML_AB1 ML_AB2 ML_AB3 ML_AB4 ML_AB_NEW
 ```
 
-Pymlff also includes a command line utility for converting ML_AB files to extended xyz (extxyz) files.
+Pymlff also includes a command line utility for converting ML_AB files to extended xyz (extxyz) files. The last argument is the units to use for converting the VASP kbar units. Valid units are eV/A^3 and kbar.
 
 ```bash
-mlff write-extxyz ML_AB ML_AB.xyz
+mlff write-extxyz ML_AB ML_AB.xyz eV/A^3
 ```
 
 ### Python API
@@ -89,5 +89,5 @@ from pymlff import MLAB
 ab = MLAB.from_file("ML_AB")
 
 # write an extxyz file
-ab.write_extxyz("ML_AB.xyz")
+ab.write_extxyz("ML_AB.xyz", "eV/A^3")
 ```

--- a/src/pymlff/cli.py
+++ b/src/pymlff/cli.py
@@ -38,8 +38,14 @@ def merge(inputs, output):
 @cli.command()
 @click.argument("input", type=click.Path(exists=True))
 @click.argument("output", type=click.Path(exists=False))
-def write_extxyz(input, output):
-    """Convert an ML_AB file to extended xyz format."""
+@click.argument("stress_unit", type=click.Choice(["kbar", "eV/A^3"]))
+def write_extxyz(input, output, stress_unit):
+    """Convert an ML_AB file to extended xyz format.
+
+    STRESS_UNIT is the unit that the stress tensor is converted to.
+    It can be either 'kbar' or 'eV/A^3'.
+    We assume the stress tensor is in kbar in the ML_AB file.
+    """
     from pymlff import MLAB
 
     try:
@@ -48,4 +54,4 @@ def write_extxyz(input, output):
         click.echo(f"ERROR: Could not read ML_AB file: {input}")
         sys.exit()
 
-    ml_ab.write_extxyz(output)
+    ml_ab.write_extxyz(output, stress_unit=stress_unit)

--- a/src/pymlff/core.py
+++ b/src/pymlff/core.py
@@ -294,7 +294,7 @@ class MLAB:
         with open(filename, "w") as f:
             f.write(self.to_string())
 
-    def write_extxyz(self, filename):
+    def write_extxyz(self, filename, stress_unit):
         """
         Write MLAB object to an extended xyz file.
 
@@ -302,7 +302,10 @@ class MLAB:
         ----------
         filename
             A filename.
+        stress_unit
+            Unit of stress to convert to. VASP units are kbar. Default is 'ev/A^3'.
+            If 'ev/A^3', the stress is converted from kbar to eV/A^3.
         """
         from pymlff.io import ml_ab_to_extxyz
 
-        ml_ab_to_extxyz(self, filename)
+        ml_ab_to_extxyz(self, filename, stress_unit)

--- a/src/pymlff/io.py
+++ b/src/pymlff/io.py
@@ -304,7 +304,7 @@ def _three_fmt(obj, prefix=""):
     return f"\n{prefix}".join([" ".join(x) for x in _grouper(obj, 3)])
 
 
-def ml_ab_to_extxyz(ml_ab, filename, stress_unit='ev/A^3'):
+def ml_ab_to_extxyz(ml_ab, filename, stress_unit='eV/A^3'):
     """
     Convert an MLAB object to an extended XYZ string representation.
     Parameters
@@ -314,12 +314,12 @@ def ml_ab_to_extxyz(ml_ab, filename, stress_unit='ev/A^3'):
     filename
         Path to an extended XYZ file.
     stress_unit
-        Unit of stress. VASP units are kbar. Default is 'ev/A^3'.
+        Unit of stress to convert to. VASP units are kbar. Default is 'ev/A^3'.
         If 'ev/A^3', the stress is converted from kbar to eV/A^3.
     """
     if stress_unit == 'kbar':
         stress_unit = 1
-    elif stress_unit == 'ev/A^3':
+    elif stress_unit == 'eV/A^3':
         stress_unit = _KBAR_TO_EV_Acub
     with open(filename, 'w') as f:
         for i, conf in enumerate(ml_ab.configurations):


### PR DESCRIPTION
- Can now specify the units to convert the stress to through the CLI and through the Python API

API example:
```python
from pymlff import MLAB

# Load file
ab = MLAB.from_file("ML_ABN")

# Write xyz file with stress units in kbar
ab = MLAB.write_extxyz("ML_AB_kbar.xyz", "kbar")

# Write xyz file with stress units in eV/A^3
ab = MLAB.write_extxyz("ML_AB_eV.xyz", "eV/A^3")
```

CLI example:
```bash

# Write xyz file with stress units in kbar
mlff ML_ABN ML_ABN_kbar.xyz kbar

# Write xyz file with stress units in eV/A^3
mlff ML_ABN ML_ABN_eV.xyz eV/A^3
```